### PR TITLE
Add "OFF" mode again, add README info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,16 @@
 Bridges the eq-3 MaxCube box to Apples Homekit.
 Automatically registers all devices itself so that you should instantly be able to control your home heating through Siri & your phone.
 
-##### Status of this package:
+### Status of this package:
 Experimental and dirty.
 If you're interested to help, please do so. The code needs improvement and it currently won't win a beauty contest as that was not the intention.
 
+Supports the following features of Max! thermostat devices:
+ - Setting temperature
+ - Setting the mode (AUTO/MANUAL)
+ - Displaying the measured temperature
+ - Displaying the set temperature
+ - Displaying the battery warning
 
 ## Example config
 ```
@@ -26,6 +32,21 @@ If you're interested to help, please do so. The code needs improvement and it cu
   ]
 }
 ```
-##### Explanation:
+### Explanation:
 You have to find out the ip party through your DHCP server, the rest should automatically work out of the box:
 All devices you have connected are automatically fetched from your MaxCube
+
+## Additional Notes
+
+### Heating/Cooling Mode
+HomeKit provides a "mode" setting for thermostat devices that allows toggling OFF/HEATING/COOLING/AUTO. This setting is used by this plugin to enable the "AUTO" mode of Max! thermostat devices or to turn them off (e.g. via Siri command). The following things happen when different modes are enabled:
+ 
+ - OFF: The thermostat is set to 10 degrees and manual mode.
+ - HEATING: The thermostat is set to manual mode, temperature is kept as is.
+ - COOLING: The thermostat is set to manual mode, temperature is kept as is, it will report "HEATING" when next polled.
+ - AUTO: The thermostat is set to AUTO mode.
+ 
+When the thermostat is set to 10 degrees or less manuall it will also report "OFF".
+
+### Using Max! software alongside HomeBridge
+If you want to use the Max! software to configure your Max! cube its best to first stop the homebridge server as you might get connection issues otherwise.


### PR DESCRIPTION
I cleaned up the copying of the device properties and re-introduced the "OFF" mode to set the thermostat to 10 deg.

I also added some more information about the plugin in the README.

I did not however change the version of the plugin. Do you still intend to publish a newer version to NPM at some point? Just so I know what version I keep installed on my homebridge.