### PR TITLE
Added automatic device updates, some fixes and cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Bridges the eq-3 MaxCube box to Apples Homekit.
 Automatically registers all devices itself so that you should instantly be able to control your home heating through Siri & your phone.
 
 ### Status of this package:
-Experimental and dirty.
+Halfway decent and tested by a handful of people, most features work as intended.
 If you're interested to help, please do so. The code needs improvement and it currently won't win a beauty contest as that was not the intention.
 
 Supports the following features of Max! thermostat devices:
@@ -40,13 +40,18 @@ All devices you have connected are automatically fetched from your MaxCube
 
 ### Heating/Cooling Mode
 HomeKit provides a "mode" setting for thermostat devices that allows toggling OFF/HEATING/COOLING/AUTO. This setting is used by this plugin to enable the "AUTO" mode of Max! thermostat devices or to turn them off (e.g. via Siri command). The following things happen when different modes are enabled:
- 
+
  - OFF: The thermostat is set to 10 degrees and manual mode.
  - HEATING: The thermostat is set to manual mode, temperature is kept as is.
  - COOLING: The thermostat is set to manual mode, temperature is kept as is, it will report "HEATING" when next polled.
  - AUTO: The thermostat is set to AUTO mode.
- 
-When the thermostat is set to 10 degrees or less manuall it will also report "OFF".
+
+When the thermostat is set to 10 degrees or less manually it will also report "OFF".
 
 ### Using Max! software alongside HomeBridge
 If you want to use the Max! software to configure your Max! cube its best to first stop the homebridge server as you might get connection issues otherwise.
+
+### Bidirectional
+The plugin works bidirectionally, if you change the temperature on your actual thermostat it will be reflected in HomeKit. However theres a delay of up to five minutes until the plugin next polls the data from the Max! cube.
+
+This also means that you can trigger scenes based on a certain room temperature etc. as the change signal is broadcast in HomeKit.

--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ If you want to increase or reduce the rate at which the data is polled from the 
 ```
 
 ### Broadcast limit
-Note that the Max! cube has a built-in limit for sending data to the thermostat devices to obey to the laws about the 868MHz band. When you play around while setting up your system you might hit that limit and wonder why the thermostat devices don't react to signals anymore. To test if that is the case stop the HomeBridge server and log in with your Max! software. It will tell you if that is the case.
+Note that the Max! cube has a built-in limit for sending data to the thermostat devices to obey to the laws about the 868MHz band. When you play around while setting up your system you might hit that limit and wonder why the thermostat devices don't react to signals anymore. To test if that is the case set the "Max! Link" switch to "off" and log in with your Max! software.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Supports the following features of Max! thermostat devices:
  - Setting the mode (AUTO/MANUAL)
  - Displaying the measured temperature
  - Displaying the set temperature
- - Displaying the battery warning
+ - Displaying the battery warning (also in Apples Home app)
+ - Displaying error warnings (only in certain apps)
 
 ## Example config
 ```
@@ -73,3 +74,18 @@ If you want to use ONLY wall thermostat devices and control everything through t
   "only_wall_thermostat": "true"
 }
 ```
+
+### Update rate
+If you want to increase or reduce the rate at which the data is polled from the cube you can add the option `update_rate` with a time in minutes to the configuration.
+```
+{
+  "platform": "MaxCubePlatform",
+  "name": "MaxCube Platform",
+  "ip": "192.168.2.20",
+  "port": 62910,
+  "update_rate": 10
+}
+```
+
+### Broadcast limit
+Note that the Max! cube has a built-in limit for sending data to the thermostat devices to obey to the laws about the 868MHz band. When you play around while setting up your system you might hit that limit and wonder why the thermostat devices don't react to signals anymore. To test if that is the case stop the HomeBridge server and log in with your Max! software. It will tell you if that is the case.

--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ All devices you have connected are automatically fetched from your MaxCube
 ### Heating/Cooling Mode
 HomeKit provides a "mode" setting for thermostat devices that allows toggling OFF/HEATING/COOLING/AUTO. This setting is used by this plugin to enable the "AUTO" mode of Max! thermostat devices or to turn them off (e.g. via Siri command). The following things happen when different modes are enabled:
 
- - OFF: The thermostat is set to 10 degrees and manual mode.
- - HEATING: The thermostat is set to manual mode, temperature is kept as is.
- - COOLING: The thermostat is set to manual mode, temperature is kept as is, it will report "HEATING" when next polled.
- - AUTO: The thermostat is set to AUTO mode.
+ - OFF: The thermostat is set to 10 degrees and manual mode. Setting any other mode when the thermostat is off will set the temperature to the default.
+ - HEATING: The thermostat is set to manual mode, temperature is kept as is if above 10.
+ - COOLING: The thermostat is set to manual mode, temperature is kept as is if above 10. The thermostat will report "HEATING" when next polled.
+ - AUTO: The thermostat is set to AUTO mode, temperature is kept as is if above 10.
+
+The default temperature when the thermostat is turned back on is 20 degrees. You can add a default_temp option to the config file to change this value, e.g. `"default_temp":22`.
 
 When the thermostat is set to 10 degrees or less manually it will also report "OFF".
 
@@ -58,7 +60,7 @@ The plugin works bidirectionally, if you change the temperature on your actual t
 This also means that you can trigger scenes based on a certain room temperature etc. as the change signal is broadcast in HomeKit.
 
 ### AUTO mode and setting the temperature
-When you set the AUTO mode it is kept even if you change the temperature via HomeKit / Siri, same for manual mode.
+When you set the AUTO mode it is kept even if you change the temperature via HomeKit / Siri, same for manual mode. When the thermostat is in AUTO mode and you change the temperature via HomeKit the Max! cube should set it back to the planned temperature on the next planned change.
 
 ### Wall thermostat devices
 Wall thermostat devices are by default not included in HomeKit but if you add the option `allow_wall_thermostat` with any value except false/0 to the configuration they will be added as well. They could be useful as they also supply the temperature.

--- a/README.md
+++ b/README.md
@@ -55,3 +55,21 @@ If you want to use the Max! software to configure your Max! cube its best to fir
 The plugin works bidirectionally, if you change the temperature on your actual thermostat it will be reflected in HomeKit. However theres a delay of up to five minutes until the plugin next polls the data from the Max! cube.
 
 This also means that you can trigger scenes based on a certain room temperature etc. as the change signal is broadcast in HomeKit.
+
+### AUTO mode and setting the temperature
+When you set the AUTO mode it is kept even if you change the temperature via HomeKit / Siri, same for manual mode.
+
+### Wall thermostat devices
+Wall thermostat devices are by default not included in HomeKit but if you add the option `allow_wall_thermostat` with any value except false/0 to the configuration they will be added as well. They could be useful as they also supply the temperature.
+
+If you want to use ONLY wall thermostat devices and control everything through them you can add the option `only_wall_thermostat` with any value except false/0, e.g.
+
+```
+{
+  "platform": "MaxCubePlatform",
+  "name": "MaxCube Platform",
+  "ip": "192.168.2.20",
+  "port": 62910,
+  "only_wall_thermostat": "true"
+}
+```

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ HomeKit provides a "mode" setting for thermostat devices that allows toggling OF
 
 When the thermostat is set to 10 degrees or less manually it will also report "OFF".
 
-### Using Max! software alongside HomeBridge
-If you want to use the Max! software to configure your Max! cube its best to first stop the homebridge server as you might get connection issues otherwise.
+### Using Max! software alongside HomeBridge / Max! Link Switch
+If you want to use the Max! software to configure your Max! cube you have to set the switch "Max! Link" in HomeKit to off, this will disconnect HomeBridge from the Max! Cube so that the Max! software can connect instead. Set it back to on to be able to control your heating from HomeKit again.
 
 ### Bidirectional
 The plugin works bidirectionally, if you change the temperature on your actual thermostat it will be reflected in HomeKit. However theres a delay of up to five minutes until the plugin next polls the data from the Max! cube.

--- a/index.js
+++ b/index.js
@@ -1,57 +1,51 @@
 var MaxCube = require('maxcube');
 var Thermostat = require('./thermostat');
 
-
 /** Sample platform outline
  *  based on Sonos platform
  */
-
 function MaxCubePlatform(log, config){
-    this.log = log;
-    this.config = config;
-    this.refreshed = false;
-    if (this.config) {
-      //this.log('Connecting to MaxCube')
-      this.cube = new MaxCube(this.config.ip, this.config.port);
-    }
+  this.log = log;
+  this.config = config;
+  this.refreshed = false;
+  if (this.config) {
+    this.cube = new MaxCube(this.config.ip, this.config.port);
+  }
 };
 MaxCubePlatform.prototype = {
-    accessories: function(callback) {
-      //this.log("Fetching maxCube devices.");
-      var that = this;
-      this.cube.maxCubeLowLevel.on('error', function (error) {
-          that.log("Max! Cube Error:", error);
-      });
-      this.cube.on('connected', function () {
-        //that.log('Connected');
-
+  accessories: function(callback) {
+    var that = this;
+    this.cube.maxCubeLowLevel.on('error', function (error) {
+      that.log("Max! Cube Error:", error);
+      if(!this.refreshed){
+        // We didn't connect yet and got an error,
+        // probably the Cube couldn't be reached,
+        // fulfill the callback so HomeBridge can initialize.
         var myAccessories = [];
-        that.cube.getDeviceStatus().then(function (devices) {
-          if (this.refreshed){
-            //that.log('Already refreshed');
-            return;
+        callback(myAccessories);
+      }
+    });
+    this.cube.on('connected', function () {
+      var myAccessories = [];
+      if (this.refreshed) return;
+      that.cube.getDeviceStatus().then(function (devices) {
+        this.refreshed = true;
+        devices.forEach(function (device) {
+          var deviceInfo = that.cube.getDeviceInfo(device.rf_address);
+          var wall = that.config.allow_wall_thermostat && (deviceInfo.device_type == 3);
+          if (deviceInfo.device_type == 1 || deviceInfo.device_type == 2 || wall) {
+            myAccessories.push(new Thermostat(that.log, that.config, device, deviceInfo, that.cube, Service, Characteristic));
           }
-          this.refreshed = true;
-          devices.forEach(function (device) {
-            //that.log('gegting device info for '+ device.rf_address)
-            var deviceInfo = that.cube.getDeviceInfo(device.rf_address);
-
-            if (deviceInfo.device_type == 1||deviceInfo.device_type == 2) {
-              //that.log('registering device', deviceInfo.device_name+" ("+deviceInfo.room_name+")")
-              myAccessories.push(new Thermostat(that.log, that.config, device, deviceInfo, that.cube, Service, Characteristic));
-            }
-          });
-          //that.cube.close();
-          callback(myAccessories);
         });
+        callback(myAccessories);
       });
-    }
+    });
+  }
 };
 
 var Service;
 var Characteristic;
 
-// more
 module.exports = function(homebridge) {
   Service = homebridge.hap.Service;
   Characteristic = homebridge.hap.Characteristic;

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ function MaxCubePlatform(log, config){
   this.log = log;
   this.config = config;
   this.refreshed = false;
+  this.myAccessories = [];
   if (this.config) {
     this.cube = new MaxCube(this.config.ip, this.config.port);
   }
@@ -21,12 +22,10 @@ MaxCubePlatform.prototype = {
         // We didn't connect yet and got an error,
         // probably the Cube couldn't be reached,
         // fulfill the callback so HomeBridge can initialize.
-        var myAccessories = [];
-        callback(myAccessories);
+        callback(that.myAccessories);
       }
     });
     this.cube.on('connected', function () {
-      var myAccessories = [];
       if (that.refreshed) return;
       that.cube.getDeviceStatus().then(function (devices) {
         that.refreshed = true;
@@ -34,12 +33,26 @@ MaxCubePlatform.prototype = {
           var deviceInfo = that.cube.getDeviceInfo(device.rf_address);
           var wall = that.config.allow_wall_thermostat && (deviceInfo.device_type == 3);
           if (deviceInfo.device_type == 1 || deviceInfo.device_type == 2 || wall) {
-            myAccessories.push(new Thermostat(that.log, that.config, device, deviceInfo, that.cube, Service, Characteristic));
+            that.myAccessories.push(new Thermostat(that.log, that.config, device, deviceInfo, that.cube, Service, Characteristic));
           }
         });
-        callback(myAccessories);
+        setTimeout(that.updateThermostatData.bind(that),300000);
+        callback(that.myAccessories);
       });
     });
+  },
+  updateThermostatData: function(){
+    var that = this;
+    this.cube.getConnection().then(function () {
+      that.cube.getDeviceStatus().then(function (devices) {
+        devices.forEach(function (device) {
+          that.myAccessories.forEach(function(thermostat){
+            thermostat.refreshDevice(device);
+          });
+        });
+      });
+    });
+    setTimeout(this.updateThermostatData.bind(this),300000);
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,11 @@ function MaxCubePlatform(log, config){
   this.refreshed = false;
   this.myAccessories = [];
   if (this.config) {
+    if(this.config.update_rate){
+      this.updateRate = this.config.update_rate * 60000;
+    }else{
+      this.updateRate = 300000;
+    }
     this.cube = new MaxCube(this.config.ip, this.config.port);
   }
 };
@@ -37,7 +42,7 @@ MaxCubePlatform.prototype = {
             that.myAccessories.push(new Thermostat(that.log, that.config, device, deviceInfo, that.cube, Service, Characteristic));
           }
         });
-        setTimeout(that.updateThermostatData.bind(that),300000);
+        setTimeout(that.updateThermostatData.bind(that),that.updateRate);
         callback(that.myAccessories);
       });
     });
@@ -53,7 +58,7 @@ MaxCubePlatform.prototype = {
         });
       });
     });
-    setTimeout(this.updateThermostatData.bind(this),300000);
+    setTimeout(this.updateThermostatData.bind(this),this.updateRate);
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -31,8 +31,9 @@ MaxCubePlatform.prototype = {
         that.refreshed = true;
         devices.forEach(function (device) {
           var deviceInfo = that.cube.getDeviceInfo(device.rf_address);
-          var wall = that.config.allow_wall_thermostat && (deviceInfo.device_type == 3);
-          if (deviceInfo.device_type == 1 || deviceInfo.device_type == 2 || wall) {
+          var isWall = that.config.allow_wall_thermostat && (deviceInfo.device_type == 3);
+          var deviceTypeOk = that.config.only_wall_thermostat ? (deviceInfo.device_type == 3) : (deviceInfo.device_type == 1 || deviceInfo.device_type == 2);
+          if (deviceTypeOk || isWall) {
             that.myAccessories.push(new Thermostat(that.log, that.config, device, deviceInfo, that.cube, Service, Characteristic));
           }
         });

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ MaxCubePlatform.prototype = {
     var that = this;
     this.cube.maxCubeLowLevel.on('error', function (error) {
       that.log("Max! Cube Error:", error);
-      if(!this.refreshed){
+      if(!that.refreshed){
         // We didn't connect yet and got an error,
         // probably the Cube couldn't be reached,
         // fulfill the callback so HomeBridge can initialize.
@@ -27,9 +27,9 @@ MaxCubePlatform.prototype = {
     });
     this.cube.on('connected', function () {
       var myAccessories = [];
-      if (this.refreshed) return;
+      if (that.refreshed) return;
       that.cube.getDeviceStatus().then(function (devices) {
-        this.refreshed = true;
+        that.refreshed = true;
         devices.forEach(function (device) {
           var deviceInfo = that.cube.getDeviceInfo(device.rf_address);
           var wall = that.config.allow_wall_thermostat && (deviceInfo.device_type == 3);

--- a/thermostat.js
+++ b/thermostat.js
@@ -144,27 +144,40 @@ Thermostat.prototype = {
     var that = this;
     var targetCoolingState = 'MANUAL';
     var targetTemp = that.device.setpoint;
-    if(value == 0) {
-      this.coolingState = Characteristic.TargetHeatingCoolingState.OFF;
+    if(value == Characteristic.TargetHeatingCoolingState.OFF) {
+      this.coolingState = value;
       targetTemp = 10;
+      that.thermostatService.getCharacteristic(Characteristic.TargetTemperature).updateValue(targetTemp);
     }
-    else if(value == 1) {
+    else if(value == Characteristic.TargetHeatingCoolingState.HEAT) {
+      this.coolingState = value;
+      if(targetTemp <= 10){
+        targetTemp = 20;
+        that.thermostatService.getCharacteristic(Characteristic.TargetTemperature).updateValue(targetTemp);
+      }
+    }
+    else if(value == Characteristic.TargetHeatingCoolingState.COOL) {
       this.coolingState = Characteristic.TargetHeatingCoolingState.HEAT;
+      if(targetTemp <= 10){
+        targetTemp = 20;
+        that.thermostatService.getCharacteristic(Characteristic.TargetTemperature).updateValue(targetTemp);
+      }
     }
-    else if(value == 2) {
-      //this.coolingState = Characteristic.TargetHeatingCoolingState.COOL;
-      this.coolingState = Characteristic.TargetHeatingCoolingState.HEAT;
-    }
-    else if(value == 3) {
-      this.coolingState = Characteristic.TargetHeatingCoolingState.AUTO;
+    else if(value == Characteristic.TargetHeatingCoolingState.AUTO) {
+      this.coolingState = value;
+      if(targetTemp <= 10){
+        targetTemp = 20;
+        that.thermostatService.getCharacteristic(Characteristic.TargetTemperature).updateValue(targetTemp);
+      }
       targetCoolingState = 'AUTO';
     } else {
       that.log("Unknown HeatingCoolingState value");
     }
     this.device.mode = targetCoolingState;
+    this.device.setpoint = targetTemp;
     this.cube.getConnection().then(function () {
       that.log(that.name+' - setting mode '+targetCoolingState+' at temperature '+targetTemp);
-      that.cube.setTemperature(that.device.rf_address, targetTemp, targetCoolingState);
+      that.cube.setTemperature(that.device.rf_address, Math.round(targetTemp), targetCoolingState);
     });
     callback(null, this.coolingState);
   },
@@ -179,7 +192,7 @@ Thermostat.prototype = {
     this.device.setpoint = value;
     this.cube.getConnection().then(function () {
       that.log(that.name+' - setting temperature '+ value);
-      that.cube.setTemperature(that.device.rf_address, value, that.device.mode);
+      that.cube.setTemperature(that.device.rf_address, Math.round(value), that.device.mode);
     });
     callback(null, value);
   },

--- a/thermostat.js
+++ b/thermostat.js
@@ -37,6 +37,7 @@ function Thermostat(log, config, device, deviceInfo, cube, service, characterist
   this.lastNonZeroTemp = this.device.temp;
   this.name = this.deviceInfo.device_name + ' (' + this.deviceInfo.room_name + ')';
   this.temperatureDisplayUnits = Characteristic.TemperatureDisplayUnits.CELSIUS;
+  this.defaultTemp = config.default_temp?config.default_temp:20;
   if(this.device.mode == "AUTO"){
     this.coolingState = Characteristic.TargetHeatingCoolingState.AUTO;
   } else {
@@ -152,21 +153,21 @@ Thermostat.prototype = {
     else if(value == Characteristic.TargetHeatingCoolingState.HEAT) {
       this.coolingState = value;
       if(targetTemp <= 10){
-        targetTemp = 20;
+        targetTemp = this.defaultTemp;
         that.thermostatService.getCharacteristic(Characteristic.TargetTemperature).updateValue(targetTemp);
       }
     }
     else if(value == Characteristic.TargetHeatingCoolingState.COOL) {
       this.coolingState = Characteristic.TargetHeatingCoolingState.HEAT;
       if(targetTemp <= 10){
-        targetTemp = 20;
+        targetTemp = this.defaultTemp;
         that.thermostatService.getCharacteristic(Characteristic.TargetTemperature).updateValue(targetTemp);
       }
     }
     else if(value == Characteristic.TargetHeatingCoolingState.AUTO) {
       this.coolingState = value;
       if(targetTemp <= 10){
-        targetTemp = 20;
+        targetTemp = this.defaultTemp;
         that.thermostatService.getCharacteristic(Characteristic.TargetTemperature).updateValue(targetTemp);
       }
       targetCoolingState = 'AUTO';

--- a/thermostat.js
+++ b/thermostat.js
@@ -175,10 +175,20 @@ Thermostat.prototype = {
     }
     this.device.mode = targetCoolingState;
     this.device.setpoint = targetTemp;
-    this.cube.getConnection().then(function () {
-      that.log(that.name+' - setting mode '+targetCoolingState+' at temperature '+targetTemp);
-      that.cube.setTemperature(that.device.rf_address, Math.round(targetTemp), targetCoolingState);
-    });
+    if(this.cube) try{
+      this.cube.getConnection().then(function () {
+        that.log(that.name+' - setting mode '+targetCoolingState+' at temperature '+targetTemp);
+        try{
+          that.cube.setTemperature(that.device.rf_address, Math.round(targetTemp), targetCoolingState);
+        }
+        catch(err){
+          that.log("Error sending data to Max! Cube: "+ err);
+        }
+      });
+    }
+    catch(err){
+      that.log("Error sending data to Max! Cube: "+ err);
+    }
     callback(null, this.coolingState);
   },
   getCurrentTemperature: function(callback) {
@@ -190,10 +200,20 @@ Thermostat.prototype = {
   setTargetTemperature: function(value, callback) {
     var that = this;
     this.device.setpoint = value;
-    this.cube.getConnection().then(function () {
-      that.log(that.name+' - setting temperature '+ value);
-      that.cube.setTemperature(that.device.rf_address, Math.round(value), that.device.mode);
-    });
+    if(this.cube) try{
+      this.cube.getConnection().then(function () {
+        that.log(that.name+' - setting temperature '+ value);
+        try{
+          that.cube.setTemperature(that.device.rf_address, Math.round(value), that.device.mode);
+        }
+        catch(err){
+          that.log("Error sending data to Max! Cube: "+ err);
+        }
+      });
+    }
+    catch(err){
+      that.log("Error sending data to Max! Cube: "+ err);
+    }
     callback(null, value);
   },
   getTemperatureDisplayUnits: function(callback) {

--- a/thermostat.js
+++ b/thermostat.js
@@ -21,76 +21,118 @@ deviceInfo:
   device_name: 'Süden',
   room_name: 'Stube',
   room_id: 1 }
+device_type 1+2 = Thermostat
+device_type 3 = Wall Thermostat (same data layout)
+device_type 4 = Window Sensor (no data except rf_address)
+device_type 5 = Eco Button (no data except rf_address)
 */
 function Thermostat(log, config, device, deviceInfo, cube, service, characteristic){
+  Service = service;
+  Characteristic = characteristic;
+  this.log = log;
+  this.config = config;
+  this.device = device;
+  this.deviceInfo = deviceInfo;
+  this.cube = cube;
+  this.lastNonZeroTemp = this.device.temp;
+  this.name = this.deviceInfo.device_name + ' (' + this.deviceInfo.room_name + ')';
+  this.temperatureDisplayUnits = Characteristic.TemperatureDisplayUnits.CELSIUS;
+  if(this.device.mode == "AUTO"){
+    this.coolingState = Characteristic.TargetHeatingCoolingState.AUTO;
+  } else {
+    this.coolingState = Characteristic.TargetHeatingCoolingState.HEAT;
+  }
+  if(this.device.setpoint <= 10){
+    this.coolingState = Characteristic.TargetHeatingCoolingState.OFF;
+  }
 
-    this.log = log;
-    this.config = config;
-    this.device = device;
-    this.deviceInfo = deviceInfo;
+  this.informationService = new Service.AccessoryInformation();
+  this.informationService
+    .setCharacteristic(Characteristic.Manufacturer, 'EQ-3')
+    .setCharacteristic(Characteristic.Model, 'EQ3 - '+ this.device.rf_address)
+    .setCharacteristic(Characteristic.SerialNumber, this.device.rf_address)
 
-    this.cube = cube;
+  this.thermostatService = new Service.Thermostat(this.device.address);
+  this.thermostatService
+    .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+    .on('get', this.getCurrentHeatingCoolingState.bind(this));
 
-    this.lastNonZeroTemp = this.device.temp;
+  this.thermostatService
+    .getCharacteristic(Characteristic.TargetHeatingCoolingState)
+    .on('get', this.getTargetHeatingCoolingState.bind(this))
+    .on('set', this.setTargetHeatingCoolingState.bind(this));
 
-    Service = service;
-    Characteristic = characteristic;
+  this.thermostatService
+    .getCharacteristic(Characteristic.CurrentTemperature)
+    .on('get', this.getCurrentTemperature.bind(this));
 
-    // set the name
-    this.name = this.deviceInfo.device_name + ' (' + this.deviceInfo.room_name + ')';
+  this.thermostatService
+    .getCharacteristic(Characteristic.TargetTemperature)
+    .on('get', this.getTargetTemperature.bind(this))
+    .on('set', this.setTargetTemperature.bind(this));
 
-    // set the temperatur to celcius
-    this.temperatureDisplayUnits = Characteristic.TemperatureDisplayUnits.CELSIUS;
+  this.thermostatService
+    .getCharacteristic(Characteristic.TemperatureDisplayUnits)
+    .on('get', this.getTemperatureDisplayUnits.bind(this));
 
-    if(this.device.mode == "AUTO"){
-      this.coolingState = Characteristic.TargetHeatingCoolingState.AUTO;
-    } else {
-      this.coolingState = Characteristic.TargetHeatingCoolingState.HEAT;
-    }
-    if(this.device.setpoint <= 10){
-      this.coolingState = Characteristic.TargetHeatingCoolingState.OFF;
-    }
-  };
+  this.thermostatService
+    .addCharacteristic(Characteristic.StatusLowBattery)
+    .on('get', this.getLowBatteryStatus.bind(this));
+};
 
 Thermostat.prototype = {
-  refreshDevice: function(){
+  refreshDevice: function(device){
+    // this is called by the global data update loop
+    if(device.rf_address!=this.device.rf_address) return;
     var that = this;
-    this.cube.getConnection().then(function () {
-      that.cube.getDeviceStatus(that.device.rf_address).then(function (devices) {
-        devices.forEach(function (device) {
-          that.device = device;
-          if(that.device.mode == "AUTO"){
-            that.coolingState = Characteristic.TargetHeatingCoolingState.AUTO;
-          } else {
-            that.coolingState = Characteristic.TargetHeatingCoolingState.HEAT;
-          }
-          if(that.device.setpoint <= 10){
-            that.coolingState = Characteristic.TargetHeatingCoolingState.OFF;
-          }
-          if(that.device.temp != 0){
-            that.lastNonZeroTemp = that.device.temp;
-          }
-        });
-      });
-    });
+    var oldDevice = that.device;
+    that.device = device;
+    if(that.device.mode == "AUTO"){
+      that.coolingState = Characteristic.TargetHeatingCoolingState.AUTO;
+    } else {
+      that.coolingState = Characteristic.TargetHeatingCoolingState.HEAT;
+    }
+    if(that.device.setpoint <= 10){
+      that.coolingState = Characteristic.TargetHeatingCoolingState.OFF;
+    }
+    if(that.device.temp != 0){
+      that.lastNonZeroTemp = that.device.temp;
+    }
+    that.publishNewData(oldDevice);
+  },
+  publishNewData: function(oldDevice){
+    // publish changes in data so events can be triggered by data changes
+    var that = this;
+    if(oldDevice.mode != that.device.mode){
+      that.thermostatService.getCharacteristic(Characteristic.TargetHeatingCoolingState).updateValue(that.coolingState);
+      that.log(that.name+' - Broadcast target mode due to new data.');
+    }
+    if(oldDevice.battery_low != that.device.battery_low){
+      that.thermostatService.getCharacteristic(Characteristic.StatusLowBattery).updateValue(that.device.battery_low);
+      that.log(that.name+' - Broadcast battery state due to new data.');
+    }
+    if(oldDevice.setpoint != that.device.setpoint){
+      that.thermostatService.getCharacteristic(Characteristic.TargetTemperature).updateValue(that.device.setpoint);
+      that.log(that.name+' - Broadcast target temperature due to new data.');
+    }
+    if(oldDevice.temp != that.device.temp){
+      that.thermostatService.getCharacteristic(Characteristic.CurrentTemperature).updateValue(that.lastNonZeroTemp);
+      that.log(that.name+' - Broadcast temperature due to new data.');
+    }
   },
   getCurrentHeatingCoolingState: function(callback) {
-     this.refreshDevice();
-     if(this.coolingState == Characteristic.TargetHeatingCoolingState.AUTO){
-       //current state can't be "AUTO"
-       callback(null, Characteristic.TargetHeatingCoolingState.HEAT);
-     }
-     else {
-       callback(null, this.coolingState);
-     }
+    if(this.coolingState == Characteristic.TargetHeatingCoolingState.AUTO){
+      //current state can't be "AUTO"
+      callback(null, Characteristic.TargetHeatingCoolingState.HEAT);
+    }
+    else {
+      callback(null, this.coolingState);
+    }
   },
-
   getTargetHeatingCoolingState: function(callback) {
-     this.refreshDevice();
-     callback(null, this.coolingState);
+    callback(null, this.coolingState);
   },
   setTargetHeatingCoolingState: function(value, callback) {
-    this.refreshDevice();
     var that = this;
     var targetCoolingState = 'MANUAL';
     var targetTemp = that.device.setpoint;
@@ -111,78 +153,36 @@ Thermostat.prototype = {
     } else {
       that.log("Unknown HeatingCoolingState value");
     }
+    this.device.mode = targetCoolingState;
     this.cube.getConnection().then(function () {
-      that.log('setting mode '+targetCoolingState+' at temperature '+targetTemp+'deg');
+      that.log(that.name+' - setting mode '+targetCoolingState+' at temperature '+targetTemp);
       that.cube.setTemperature(that.device.rf_address, targetTemp, targetCoolingState);
     });
     callback(null, this.coolingState);
   },
-
   getCurrentTemperature: function(callback) {
-    this.refreshDevice();
     callback(null, this.lastNonZeroTemp);
   },
-
   getTargetTemperature: function(callback) {
-    this.refreshDevice();
     callback(null, this.device.setpoint);
   },
-
   setTargetTemperature: function(value, callback) {
     var that = this;
-    that.refreshDevice();
+    this.device.setpoint = value;
     this.cube.getConnection().then(function () {
-      that.log('setting temperature: '+ value);
+      that.log(that.name+' - setting temperature: '+ value);
       that.cube.setTemperature(that.device.rf_address, value, that.device.mode);
     });
     callback(null, value);
   },
-
   getTemperatureDisplayUnits: function(callback) {
-    var error = null;
-    callback(error, this.temperatureDisplayUnits);
+    callback(null, this.temperatureDisplayUnits);
   },
   getLowBatteryStatus: function(callback) {
-    this.refreshDevice();
     callback(null, this.device.battery_low);
   },
-
   getServices: function(){
-    var informationService = new Service.AccessoryInformation();
-    informationService
-      .setCharacteristic(Characteristic.Manufacturer, 'EQ-3')
-      .setCharacteristic(Characteristic.Model, 'EQ3 - '+ this.device.rf_address)
-      .setCharacteristic(Characteristic.SerialNumber, this.device.rf_address)
-
-    var thermostatService = new Service.Thermostat(this.device.address);
-      thermostatService
-        .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
-        .on('get', this.getCurrentHeatingCoolingState.bind(this));
-
-      thermostatService
-        .getCharacteristic(Characteristic.TargetHeatingCoolingState)
-        .on('get', this.getTargetHeatingCoolingState.bind(this))
-        .on('set', this.setTargetHeatingCoolingState.bind(this));
-
-      thermostatService
-        .getCharacteristic(Characteristic.CurrentTemperature)
-        .on('get', this.getCurrentTemperature.bind(this));
-
-      thermostatService
-        .getCharacteristic(Characteristic.TargetTemperature)
-        .on('get', this.getTargetTemperature.bind(this))
-        .on('set', this.setTargetTemperature.bind(this));
-
-      thermostatService
-        .getCharacteristic(Characteristic.TemperatureDisplayUnits)
-        .on('get', this.getTemperatureDisplayUnits.bind(this));
-
-      thermostatService
-        .addCharacteristic(new Characteristic.StatusLowBattery())
-        .on('get', this.getLowBatteryStatus.bind(this));
-
-      return [informationService,thermostatService];
+    return [this.informationService,this.thermostatService];
   }
 }
-
 module.exports = Thermostat;


### PR DESCRIPTION
A lot of stuff was shuffled around and cleaned up, see the actual changes below. Afaics this concludes what I intend to change about the plugin, I guess after a few days of testing this could be published.

- Fix plugin stalling HomeBridge when cube can't be found on startup
- Added option to use wall thermostat devices via optional allow_wall_thermostat config setting
- Allow using only wall thermostats via only_wall_thermostat
- Added automatic update of data for scene triggers etc.
- Added optional update_interval config option
- Added error status for thermostat devices (visible only in some apps)
- Fix async logic issue with refresh
- Some smaller fixes