### PR TITLE
Patch Window Sensor

### DIFF
--- a/contactsensor.js
+++ b/contactsensor.js
@@ -1,0 +1,74 @@
+var Service;
+var Characteristic;
+//{"rf_address":"181517","open":false}
+function ContactSensor(log, config, device, deviceInfo, cube, service, characteristic){
+  Service = service;
+  Characteristic = characteristic;
+  this.log = log;
+  this.config = config;
+  this.device = device;
+  this.deviceInfo = deviceInfo;
+  this.cube = cube;
+  this.open = this.device.open;
+  this.name = this.deviceInfo.device_name;
+
+
+  this.informationService = new Service.AccessoryInformation();
+  this.informationService
+    .setCharacteristic(Characteristic.Manufacturer, 'EQ-3')
+    .setCharacteristic(Characteristic.Model, 'EQ3 - '+ this.device.rf_address)
+    .setCharacteristic(Characteristic.SerialNumber, this.device.rf_address)
+
+  this.contactService = new Service.ContactSensor(this.device.address);
+  this.contactService
+    .getCharacteristic(Characteristic.ContactSensorState)
+    .on('get', this.getContactSensorState.bind(this));
+
+  this.contactService
+    .addCharacteristic(new Characteristic.StatusLowBattery())
+    .on('get', this.getLowBatteryStatus.bind(this));
+
+};
+
+ContactSensor.prototype = {
+  refreshDevice: function(device){
+    // this is called by the global data update loop
+    if(device.rf_address!=this.device.rf_address) return;
+    var that = this;
+    var oldDevice = that.device;
+    if(device.open) {
+      that.openState = Characteristic.ContactSensorState.CONTACT_NOT_DETECTED;
+    }
+    else {
+      that.openState = Characteristic.ContactSensorState.CONTACT_DETECTED;
+    }
+    that.publishNewData(oldDevice);
+  },
+  publishNewData: function(oldDevice){
+    // publish changes in data so events can be triggered by data changes
+    var that = this;
+    if(oldDevice.open != that.openState){
+      that.contactService.getCharacteristic(Characteristic.ContactSensorState).updateValue(that.openState);
+      that.device.open = (that.openState?true:false);
+      that.log(that.name+' - received new open '+ that.openState);
+    }
+    if(oldDevice.battery_low != that.device.battery_low){
+      that.contactService.getCharacteristic(Characteristic.StatusLowBattery).updateValue(that.device.battery_low);
+      that.log(that.name+' - received new low battery state '+that.device.battery_low);
+    }
+
+  },
+  getContactSensorState: function(callback) {
+    callback(null, this.device.open);
+  },
+  getLowBatteryStatus: function(callback) {
+    callback(null, this.device.battery_low);
+  },
+  getErrorStatus: function(callback) {
+    callback(null, this.device.error||this.device.link_error);
+  },
+  getServices: function(){
+    return [this.informationService,this.contactService];
+  }
+}
+module.exports = ContactSensor;

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ function MaxCubePlatform(log, config){
   this.log = log;
   this.config = config;
   this.refreshed = false;
+  this.windowsensor = config["windowsensor"] || false;
   this.myAccessories = [];
   this.myAccessories.push(new MaxCubeLinkSwitchAccessory(this.log, this.config, this));
   if(this.config.update_rate){
@@ -73,7 +74,7 @@ MaxCubePlatform.prototype = {
           var isShutter = deviceInfo.device_type == 4
           var isWall = that.config.allow_wall_thermostat && (deviceInfo.device_type == 3);
           var deviceTypeOk = that.config.only_wall_thermostat ? (deviceInfo.device_type == 3) : (deviceInfo.device_type == 1 || deviceInfo.device_type == 2);
-          if (isShutter) {
+          if (isShutter && this.windowsensor) {
             that.myAccessories.push(new ContactSensor(that.log, that.config, device, deviceInfo, that.cube, Service, Characteristic));
           }
           if (deviceTypeOk || isWall) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var MaxCube = require('maxcube');
 var Thermostat = require('./thermostat');
+var ContactSensor = require('./contactsensor');
 
 /** Sample platform outline
  *  based on Sonos platform
@@ -69,8 +70,12 @@ MaxCubePlatform.prototype = {
         that.refreshed = true;
         devices.forEach(function (device) {
           var deviceInfo = that.cube.getDeviceInfo(device.rf_address);
+          var isShutter = deviceInfo.device_type == 4
           var isWall = that.config.allow_wall_thermostat && (deviceInfo.device_type == 3);
           var deviceTypeOk = that.config.only_wall_thermostat ? (deviceInfo.device_type == 3) : (deviceInfo.device_type == 1 || deviceInfo.device_type == 2);
+          if (isShutter) {
+            that.myAccessories.push(new ContactSensor(that.log, that.config, device, deviceInfo, that.cube, Service, Characteristic));
+          }
           if (deviceTypeOk || isWall) {
             that.myAccessories.push(new Thermostat(that.log, that.config, device, deviceInfo, that.cube, Service, Characteristic));
           }

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ MaxCubePlatform.prototype = {
     }
   },
   updateThermostatData: function(){
-    // called periodically
+    //called periodically
     setTimeout(this.updateThermostatData.bind(this),this.updateRate);
     if(!this.cube) return;
     var that = this;

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ MaxCubePlatform.prototype = {
     }
   },
   updateThermostatData: function(){
-    //called periodically
+    // called periodically
     setTimeout(this.updateThermostatData.bind(this),this.updateRate);
     if(!this.cube) return;
     var that = this;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "homebridge": ">=0.4.0"
   },
   "dependencies": {
-    "maxcube": "git+https://github.com/DanielWeeber/maxcube.git"
+    "maxcube-window": ">=1.0.0"
   },
   "devDependencies": {
     "homebridge": "0.4.10"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "homebridge": ">=0.4.0"
   },
   "dependencies": {
-    "maxcube": "^1.0.6"
+    "maxcube": "git+https://github.com/DanielWeeber/maxcube.git"
   },
   "devDependencies": {
     "homebridge": "0.4.10"

--- a/thermostat.js
+++ b/thermostat.js
@@ -35,7 +35,7 @@ function Thermostat(log, config, device, deviceInfo, cube, service, characterist
   this.deviceInfo = deviceInfo;
   this.cube = cube;
   this.lastNonZeroTemp = this.device.temp;
-  this.name = this.deviceInfo.device_name;
+  this.name = this.deviceInfo.device_name + ' (' + this.deviceInfo.room_name + ')';
   this.temperatureDisplayUnits = Characteristic.TemperatureDisplayUnits.CELSIUS;
   this.defaultTemp = config.default_temp?config.default_temp:20;
   if(this.device.mode == "AUTO"){

--- a/thermostat.js
+++ b/thermostat.js
@@ -35,7 +35,7 @@ function Thermostat(log, config, device, deviceInfo, cube, service, characterist
   this.deviceInfo = deviceInfo;
   this.cube = cube;
   this.lastNonZeroTemp = this.device.temp;
-  this.name = this.deviceInfo.device_name + ' (' + this.deviceInfo.room_name + ')';
+  this.name = this.deviceInfo.device_name;
   this.temperatureDisplayUnits = Characteristic.TemperatureDisplayUnits.CELSIUS;
   this.defaultTemp = config.default_temp?config.default_temp:20;
   if(this.device.mode == "AUTO"){
@@ -69,6 +69,11 @@ function Thermostat(log, config, device, deviceInfo, cube, service, characterist
 
   this.thermostatService
     .getCharacteristic(Characteristic.TargetTemperature)
+    .setProps({
+      minValue: 10,
+      maxValue: 30,
+      minStep: 1
+    })
     .on('get', this.getTargetTemperature.bind(this))
     .on('set', this.setTargetTemperature.bind(this));
 


### PR DESCRIPTION
Make Window Sensors available in HomeKit via homebridge-platform-maxcube and forked version of library.

Battery low of Window Sensor does not work yet (not reported from library), will fix that in the future.

Limit Thermostat Setting to max 30 Degrees, so you cannot enter invalid value in HomeKit (slide to more than 30 degrees)

Change this.name to only contain the name, not the room in brackets.